### PR TITLE
Fix syntax error with Default.sublime-keymap

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -35,5 +35,5 @@
         "match_all": true
       }
     ]
-  },
+  }
 ]


### PR DESCRIPTION
My Sublime Text 2 was initializing with an error popup about the syntax error in Default.sublime-keymap. This change should fix the syntax error. 