### PR TITLE
Format on save, errors in panel

### DIFF
--- a/Menus/Main.sublime-menu
+++ b/Menus/Main.sublime-menu
@@ -1,0 +1,26 @@
+[
+    {
+        "id": "preferences",
+        "children":
+        [{
+            "id": "package-settings",
+            "children":
+            [
+                {
+                    "caption": "Elixir",
+                    "children":
+                    [
+                        {
+                            "caption": "Settings",
+                            "command": "edit_settings",
+                            "args": {
+                                "base_file": "${packages}/Elixir/Settings/Elixir.sublime-settings",
+                                "default": "// Settings in here override those in \"Elixir/Settings/Elixir.sublime-settings\",\n\n{\n\t$0\n}\n"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }]
+    }
+]

--- a/README.markdown
+++ b/README.markdown
@@ -45,3 +45,7 @@ You can also add your own keybindings as follows:
 
     { "keys": ["super+e"], "command": "mix_format_file" }
 
+You can also set up the package to automatically format the file on save. To do this,
+go to Preferences -> Package Settings -> Elixir -> Settings and add
+`"mix_format_on_save": true`.
+

--- a/Settings/Elixir.sublime-settings
+++ b/Settings/Elixir.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "mix_format_on_save": false
+}

--- a/mix_format_file.py
+++ b/mix_format_file.py
@@ -6,6 +6,24 @@ import subprocess
 class MixFormatFileCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     window = self.view.window()
+    window.run_command("save")
+    window.run_command("mix_format_file_without_save")
+
+class MixFormatOnSave(sublime_plugin.EventListener):
+  def on_post_save(self, view):
+    sel = view.sel()[0]
+    region = view.word(sel)
+    scope = view.scope_name(region.b)
+
+    if scope.find('source.elixir') != -1:
+      settings = sublime.load_settings('Elixir.sublime-settings')
+
+      if settings.get('mix_format_on_save', False):
+        view.run_command('mix_format_file_without_save')
+
+class MixFormatFileWithoutSaveCommand(sublime_plugin.TextCommand):
+  def run(self, edit):
+    window = self.view.window()
 
     # Hide the console window on Windows
     shell = False
@@ -41,14 +59,3 @@ class MixFormatFileCommand(sublime_plugin.TextCommand):
       window.status_message('Formatting successful!')
 
 
-class MixFormatOnSave(sublime_plugin.EventListener):
-  def on_post_save(self, view):
-    sel = view.sel()[0]
-    region = view.word(sel)
-    scope = view.scope_name(region.b)
-
-    if scope.find('source.elixir') != -1:
-      settings = sublime.load_settings('Elixir.sublime-settings')
-
-      if settings.get('mix_format_on_save', False):
-        view.run_command('mix_format_file')

--- a/mix_format_file.py
+++ b/mix_format_file.py
@@ -1,17 +1,54 @@
-import sublime, sublime_plugin, subprocess
+import os
+import sublime
+import sublime_plugin
+import subprocess
 
 class MixFormatFileCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     window = self.view.window()
-    window.run_command("save")
 
-    cmd = ["mix", "format", self.view.file_name()]
-    cwd = window.folders()[0]
-    returncode = subprocess.call(cmd, cwd=cwd)
+    # Hide the console window on Windows
+    shell = False
+    path_separator = ':'
+    if os.name == 'nt':
+        shell = True
+        path_separator = ';'
 
-    if returncode == 0:
-      window.status_message("Formatting successful!")
+    cmd = ['mix', 'format', self.view.file_name()]
+
+    p = subprocess.Popen(
+      cmd,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      shell=shell
+    )
+
+    _, stderrdata = p.communicate()
+
+    stderrdata = stderrdata.strip()
+
+    if stderrdata:
+      panel_view = window.create_output_panel('mix_format')
+      panel_view.set_read_only(False)
+
+      panel_view.run_command('erase_view')
+      panel_view.run_command('append', {'characters': stderrdata.decode()})
+
+      panel_view.set_read_only(True)
+      window.run_command('show_panel', {'panel': 'output.mix_format'})
     else:
-      # TODO: Ideally we would show errors in a pane but life
-      # is too short to figure it out. Pull requests welcome!
-      sublime.error_message("Formatting failed!")
+      window.run_command('hide_panel', {'panel': 'output.mix_format'})
+      window.status_message('Formatting successful!')
+
+
+class MixFormatOnSave(sublime_plugin.EventListener):
+  def on_post_save(self, view):
+    sel = view.sel()[0]
+    region = view.word(sel)
+    scope = view.scope_name(region.b)
+
+    if scope.find('source.elixir') != -1:
+      settings = sublime.load_settings('Elixir.sublime-settings')
+
+      if settings.get('mix_format_on_save', False):
+        view.run_command('mix_format_file')


### PR DESCRIPTION
- show `mix format` errors in panel instead of displaying hardcoded error message
- add `mix_format_on_save` option (defaults to false)
- add menu (Main -> Preferences -> Package Settings -> Elixir -> Settings) in Sublime