### PR TITLE
Fix highlighting of function parentheses

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -251,7 +251,7 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.definition.parameters.elixir</string>
+							<string>punctuation.section.function.elixir</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -324,7 +324,7 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.definition.parameters.elixir</string>
+							<string>punctuation.section.function.elixir</string>
 						</dict>
 					</dict>
 					<key>end</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -70,7 +70,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.elixir</string>
+					<string>punctuation.section.function.elixir</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
@@ -113,7 +113,7 @@
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.definition.parameters.elixir</string>
+					<string>punctuation.section.function.elixir</string>
 				</dict>
 			</dict>
 			<key>patterns</key>


### PR DESCRIPTION
### Issue

If you use this package with **Sublime Text 3** and the included color scheme **Mariana**, you will see that parentheses are colored differently on both sides of the parameter list...

This is because this package gives these parentheses different scopes.

This PR aims to correct this.

### Before applying this PR:
<img width="290" alt="screen shot 2018-01-12 at 09 37 23" src="https://user-images.githubusercontent.com/17215508/34866253-3eb9a32a-f77c-11e7-8a38-00c512dff3f7.png">

### After applying this PR:
<img width="291" alt="screen shot 2018-01-12 at 09 37 59" src="https://user-images.githubusercontent.com/17215508/34866264-4f378db6-f77c-11e7-89ee-6fb94ffb9ce5.png">

### Code used in these screenshots
```elixir
defmodule Example do

  def foo(a, b, c) do
    :foo
  end

  defp bar(a, b, c) do
    :bar
  end

  def funs() do
    f = fn (a, b, c) -> :f end

    g = fn
      (a, b, c) -> :g
    end
  end

end
```