### PR TITLE
Remove broken binary highlighting

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -471,43 +471,6 @@
 					</array>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>(::)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.binary.elixir</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(,|&gt;&gt;|$)</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.binary.elixir</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>match</key>
-							<string>\b[a-z]\w*\b</string>
-							<key>name</key>
-							<string>support.type.binary.elixir</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>\b(0x[0-9A-Fa-f](?&gt;_?[0-9A-Fa-f])*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0b[01]+|0o[0-7]+)\b</string>
-							<key>name</key>
-							<string>constant.numeric.elixir</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
 					<key>match</key>
 					<string>(?&lt;!\.)\b(do|end|case|bc|lc|for|if|cond|unless|try|receive|fn|defmodule|defp?|defprotocol|defimpl|defrecord|defstruct|defmacrop?|defdelegate|defcallback|defmacrocallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|import|require|alias|use|quote|unquote|super|with)\b(?![?!:])</string>
 					<key>name</key>


### PR DESCRIPTION
### Issue

So as far as I'm able to understand the `.tmLanguage` file (which is not so easy 😅), there is this rule that matches from `::` to `>>` to try to provide better highlighting for binary literals, but as far as I can tell, it seems to be causing more harm than good, especially because it makes highlighting inconsistent between single line typespecs and multi line typespecs (see the examples below).

I understand that simply removing these rules is a bit radical but having looked at Elixir packages for other editors like Vim and Atom, it seems to me that most other packages simply don't give any kind of special treatment to binaries, and the highlighting of the `<<`, `>>` and `::` tokens ends up yielding a satisfying result.

### Screenshots with the rules left in (before applying this PR)

#### Binaries
<img width="213" alt="screen shot 2018-01-12 at 09 54 30" src="https://user-images.githubusercontent.com/17215508/34867312-f57d6ba2-f77f-11e7-9d00-a98ee7c906e6.png">

#### Typespecs (from GenServer)
<img width="745" alt="screen shot 2018-01-12 at 09 54 40" src="https://user-images.githubusercontent.com/17215508/34867325-01064a52-f780-11e7-954f-ff239e430ac0.png">

### Screenshots with the rules removed (after applying this PR)

#### Binaries
<img width="212" alt="screen shot 2018-01-12 at 09 55 21" src="https://user-images.githubusercontent.com/17215508/34867363-1fa91dcc-f780-11e7-83a3-a4cc74b519bd.png">

#### Typespecs (from GenServer)
<img width="741" alt="screen shot 2018-01-12 at 09 55 28" src="https://user-images.githubusercontent.com/17215508/34867366-22872bba-f780-11e7-863c-19ddab53dcfe.png">

### Snippet used for binary literals
```elixir
<<1, 2, 3>>
<<0, "foo">>
<<102, rest::binary>>
<<x::8*4>>
<<x::size(8)-unit(4)>>
```