### PR TITLE
Highlight unused and wildcard variables

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1195,6 +1195,18 @@
 					<string>comment.line.number-sign.elixir</string>
 				</dict>
 				<dict>
+					<key>match</key>
+					<string>\b_([\w]+[?!]?)</string>
+					<key>name</key>
+					<string>comment.unused.elixir</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b_\b</string>
+					<key>name</key>
+					<string>comment.wildcard.elixir</string>
+				</dict>
+				<dict>
 					<key>comment</key>
 					<string>
 			matches questionmark-letters.


### PR DESCRIPTION
Hi there 👋 

### Issue

Unlike packages for other editors like Vim and Atom, this bundle did not apply special highlighting to unused / wildcard variables 😢 

This PR aims to add this feature to the TmBundle! 🙌 

### Before applying this PR

<img width="377" alt="screen shot 2018-02-16 at 14 51 57" src="https://user-images.githubusercontent.com/17215508/36310617-f63bd1b8-1328-11e8-93e1-1e40c0695f47.png">

### After applying this PR

<img width="374" alt="screen shot 2018-02-16 at 14 51 39" src="https://user-images.githubusercontent.com/17215508/36310640-ff4ef014-1328-11e8-8aa3-58190a41f97d.png">

### Code used in the screenshots

```elixir
def foo(a, _b, _) do
  {:ok, _response} = fetch_stuff()
  [_, _, the_third, _, _] = list_of_five
end
```

Best 🤗 