### PR TITLE
Highlight unused and wildcard variables (but not unimported functions)

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1196,7 +1196,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b_([\w]+[?!]?)</string>
+					<string>\b_([\w]+[?!]?)(?=[^\w?!])(?!\()</string>
 					<key>name</key>
 					<string>comment.unused.elixir</string>
 				</dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1195,6 +1195,18 @@
 					<string>comment.line.number-sign.elixir</string>
 				</dict>
 				<dict>
+					<key>match</key>
+					<string>\b_([\w]+[?!]?)</string>
+					<key>name</key>
+					<string>comment.unused.elixir</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b_\b</string>
+					<key>name</key>
+					<string>comment.wildcard.elixir</string>
+				</dict>
+				<dict>
 					<key>comment</key>
 					<string>
 			matches questionmark-letters.


### PR DESCRIPTION
Hi there 👋 

### Issue

This PR aims to add special highlighting to unused / wildcard variables to the TmBundle while addressing the issues in https://github.com/elixir-editors/elixir-tmbundle/pull/143#issuecomment-366473871.

### Before applying this PR

<img width="380" alt="screen shot 2018-02-18 at 11 53 51" src="https://user-images.githubusercontent.com/17215508/36350993-94417abe-14a2-11e8-87ae-c8887bc09e6d.png">

### After applying #143 (shown to make raised issues apparent)

<img width="383" alt="screen shot 2018-02-18 at 11 54 37" src="https://user-images.githubusercontent.com/17215508/36351000-af014604-14a2-11e8-825a-76d3a05bd3c8.png">

### After applying this PR

<img width="381" alt="screen shot 2018-02-18 at 11 53 27" src="https://user-images.githubusercontent.com/17215508/36351005-c3f930e4-14a2-11e8-83e9-31f243b8791d.png">

### Code used in the screenshots

```elixir
def foo(a, _b, _) do
  {:ok, _response} = fetch_stuff()
  [_, _, the_third, _, _] = list_of_five
end

defmodule Example do
  def _wont_be_imported do
    :oops
  end

  def _will_be_imported? do
    false
  end
end

import Example
_wont_be_imported()
_will_be_imported?()

String.__info__(:functions)
```

Best 🤗 