### PR TITLE
Highlight unused and wildcard variables episode 3

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1196,7 +1196,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b_([\w]+[?!]?)(?=[^\w?!])(?!\()</string>
+					<string>\b_([\w]+[?!]?)(?=[^\w?!])(?!(\(|/))</string>
 					<key>name</key>
 					<string>comment.unused.elixir</string>
 				</dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1196,7 +1196,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b_([\w]+[?!]?)</string>
+					<string>\b_([\w]+[?!]?)(?=[^\w?!])(?!\()</string>
 					<key>name</key>
 					<string>comment.unused.elixir</string>
 				</dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1195,6 +1195,18 @@
 					<string>comment.line.number-sign.elixir</string>
 				</dict>
 				<dict>
+					<key>match</key>
+					<string>\b_([\w]+[?!]?)</string>
+					<key>name</key>
+					<string>comment.unused.elixir</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b_\b</string>
+					<key>name</key>
+					<string>comment.wildcard.elixir</string>
+				</dict>
+				<dict>
 					<key>comment</key>
 					<string>
 			matches questionmark-letters.


### PR DESCRIPTION
Hello again ✌️

### Issue

This PR aims to add special highlighting to unused / wildcard variables to the TmBundle while addressing the issues in https://github.com/elixir-editors/elixir-tmbundle/pull/143#issuecomment-366473871 and https://github.com/elixir-editors/elixir-tmbundle/pull/145#issuecomment-366513438.

This PR manages to properly highlight unused variables and functions with a leading underscore, which I will refer to as _unimported_ functions, properly in the majority of situations. One notable situation where this PR highlights unimported functions as unused variables is when these functions are used without parentheses.

While I understand this might frustrate some users, I really would like to see this merged for the following reasons:
- It is indeed difficult to properly highlight everything using only a simple regular expression, and I would need help to make something more sophisticated, but I believe this already solves most use cases and is better than what the Vim and Atom syntaxes have to offer.
- As noted above, unimported functions seem to only be highlighted as unused variables when these functions are used without parentheses. Running the formatter on such files, however, adds the missing parentheses fixing the highlighting issue.
- I believe this highlighting of unused variables makes it much easier to see which variables are being used at a quick glance, while still allowing to keep the full names of the unused variables rather that resorting to `_`. (I am not such a fan of resorting to binding everything to `_` for the sake of readability, I would rather know which variables are at my disposal. This is of course just my opinion.)

### Before applying this PR

<img width="414" alt="screen shot 2018-02-18 at 23 49 13" src="https://user-images.githubusercontent.com/17215508/36358047-ee0b6608-1507-11e8-8ae6-be5f6aada6cc.png">

### After applying #145 (shown to make raised issues apparent)

<img width="414" alt="screen shot 2018-02-18 at 23 49 41" src="https://user-images.githubusercontent.com/17215508/36358050-fb8eff24-1507-11e8-8b53-eca75bceba09.png">

### After applying this PR

<img width="416" alt="screen shot 2018-02-18 at 23 48 31" src="https://user-images.githubusercontent.com/17215508/36358051-0164516a-1508-11e8-86f1-2a9b08458660.png">

### After applying this PR and running the code through the formatter

<img width="415" alt="screen shot 2018-02-18 at 23 48 48" src="https://user-images.githubusercontent.com/17215508/36358059-197be8a8-1508-11e8-9fcd-a0654dcb1325.png">

### Code used in the screenshots

```elixir
def foo(a, _b, _) do
  {:ok, _response} = fetch_stuff()
  [_, _, the_third, _, _] = list_of_five
end

defmodule Example do
  def _wont_be_imported do
    :oops
  end

  def _will_be_imported? do
    false
  end

  def _foo(str) do
    String.upcase(str)
  end

  def bar do
    _foo "hello"
  end

  def baz do
    ~w(qwe rty) |> Enum.map(&_foo/1)
  end
end

defmodule Test do
  def test_1 do
    Example._foo "hello"
  end

  def test_2 do
    ~w(qwe rty) |> Enum.map(&Example._foo/1)
  end
end

import Example
_wont_be_imported()
_will_be_imported?()

String.__info__(:functions)
```

I understand this is not perfect but I think it is a nice middle ground.

I am of course open to discuss this 🤗