### PR TITLE
Highlight defdelegate, defguard & defguardp

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -235,7 +235,7 @@
 
 				<dict>
 					<key>begin</key>
-					<string>^\s*(def|defmacro)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
+					<string>^\s*(def|defmacro|defdelegate)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -255,7 +255,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)|(?=\s+(def|defmacro)\b)</string>
+					<string>(\bdo:)|(\bdo\b)|(?=\s+(def|defmacro|defdelegate)\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -235,7 +235,7 @@
 
 				<dict>
 					<key>begin</key>
-					<string>^\s*(def|defmacro|defdelegate)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
+					<string>^\s*(def|defmacro|defdelegate|defguard)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -255,7 +255,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)|(?=\s+(def|defmacro|defdelegate)\b)</string>
+					<string>(\bdo:)|(\bdo\b)|(?=\s+(def|defmacro|defdelegate|defguard)\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -308,7 +308,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(defp|defmacrop)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
+					<string>^\s*(defp|defmacrop|defguardp)\s+((?&gt;[a-zA-Z_]\w*(?&gt;\.|::))?(?&gt;[a-zA-Z_]\w*(?&gt;[?!]|=(?!&gt;))?|===?|&gt;[&gt;=]?|&lt;=&gt;|&lt;[&lt;=]?|[%&amp;`/\|]|\*\*?|=?~|[-+]@?|\[\]=?))((\()|\s*)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -328,7 +328,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\bdo:)|(\bdo\b)|(?=\s+(defp|defmacrop)\b)</string>
+					<string>(\bdo:)|(\bdo\b)|(?=\s+(defp|defmacrop|defguardp)\b)</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Hi there 👋 

This PR adds highlighting to `defdelegate`, `defguard` & `defguardp`.

#### Before

<img width="645" alt="screen shot 2018-02-23 at 11 39 47" src="https://user-images.githubusercontent.com/17215508/36590319-93999dfe-188e-11e8-8dc5-e061e0b72ad3.png">

#### After

<img width="636" alt="screen shot 2018-02-23 at 11 39 24" src="https://user-images.githubusercontent.com/17215508/36590326-97309e90-188e-11e8-9956-13eae26da207.png">

#### Code used

```elixir
defmodule DefAllTheThings do
  def public_function(arg) do
    # ...
  end

  defp private_function(arg) do
    # ...
  end

  defdelegate delegate_function(arg), to: OtherModule

  defguard is_public_guard(arg) when is_public(arg) and is_guard(arg)

  defguard is_private_guard(arg) when is_private(arg) and is_guard(arg)
end
```

Best 🤗 