### PR TITLE
Capture & as part of the anonymous function

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -531,6 +531,12 @@
 					<string>variable.other.anonymous.elixir</string>
 				</dict>
 				<dict>
+					<key>match</key>
+					<string>&amp;(?![&apm;])</string>
+					<key>name</key>
+					<string>variable.other.anonymous.elixir</string>
+				</dict>
+				<dict>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This PR simply includes a raw `&` as part of the `variable.other.anonymous.elixir` scope... 

Before:
<img width="148" alt="screen shot 2018-07-15 at 4 10 01 pm" src="https://user-images.githubusercontent.com/39946/42739308-e3771100-8849-11e8-97ab-7ba1cb1d0cd0.png">

After:
<img width="121" alt="screen shot 2018-07-15 at 4 10 14 pm" src="https://user-images.githubusercontent.com/39946/42739310-e729489a-8849-11e8-888d-03a49bff2496.png">

The beginning `&` is highlighted like the capture `&1` since it now allows 0 or more following digits

I think it's really nice since it shows the connection between the two elements.