### PR TITLE
fixes typo preventing Elixir syntax from loading

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -532,7 +532,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>&amp;(?![&apm;])</string>
+					<string>&amp;(?![&amp;])</string>
 					<key>name</key>
 					<string>variable.other.anonymous.elixir</string>
 				</dict>


### PR DESCRIPTION
- It seems like a typo introduced in #150 
- TextMate 2 does not like it