### PR TITLE
Added a setting to enable reloading the file after a save…

### DIFF
--- a/Settings/Elixir.sublime-settings
+++ b/Settings/Elixir.sublime-settings
@@ -1,3 +1,4 @@
 {
-  "mix_format_on_save": false
+  "mix_format_on_save": false,
+  "reload_after_mix_format": false
 }

--- a/mix_format_file.py
+++ b/mix_format_file.py
@@ -21,6 +21,9 @@ class MixFormatOnSave(sublime_plugin.EventListener):
       if settings.get('mix_format_on_save', False):
         view.run_command('mix_format_file_without_save')
 
+        if settings.get('reload_after_mix_format', False):
+          view.run_command("revert")
+
 class MixFormatFileWithoutSaveCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     window = self.view.window()


### PR DESCRIPTION
…so changes made by `mix format` are immediately visible. Otherwise, you have to manually re-focus the file to see changes made by the formatter. Seeing changes immediately helps keep me from being surprised with the format of the code the next time I come back to it. I disabled `reload_after_mix_format` by default to prevent confusion with those used to the old behavior. This is just a suggestion, happy to hear any feedback!