### PR TITLE
improve mix format cwd detection

### DIFF
--- a/Settings/Elixir.sublime-settings
+++ b/Settings/Elixir.sublime-settings
@@ -1,4 +1,5 @@
 {
   "mix_format_on_save": false,
-  "reload_after_mix_format": false
+  "reload_after_mix_format": false,
+  "use_root_dir": false
 }


### PR DESCRIPTION
fix endless loop that keeps calling `os.dirname("/") == "/"` in case it couldn't find mix.exs
add use_root_dir setting: if set to true, always use project root dir, don't preform mix.exs lookup
improve project root dir detection - in case when there are several root dirs, pick one that shares prefix with current file