### PR TITLE
Fix the build system to work with a path that contains a space

### DIFF
--- a/Elixir - mix test $file.sublime-build
+++ b/Elixir - mix test $file.sublime-build
@@ -1,5 +1,5 @@
 {
-  "shell_cmd": "cd $folder && mix test $file",
+  "shell_cmd": "cd \"$folder\" && mix test $file",
   "working_dir": "${project_path}",
   "selector": "source.elixir"
 }

--- a/Elixir - mix test.sublime-build
+++ b/Elixir - mix test.sublime-build
@@ -1,5 +1,5 @@
 {
-  "shell_cmd": "cd $folder && mix test",
+  "shell_cmd": "cd \"$folder\" && mix test",
   "working_dir": "${project_path}",
   "selector": "source.elixir"
 }


### PR DESCRIPTION
The builds in Sublime Text would fail if your path contained a space.