### PR TITLE
Fix missing nested curly capture in string interpolation

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1411,18 +1411,13 @@
 			<key>contentName</key>
 			<string>source.elixir</string>
 			<key>end</key>
-			<string>(\})</string>
+			<string>\}</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.section.embedded.end.elixir</string>
-				</dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>source.elixir</string>
 				</dict>
 			</dict>
 			<key>name</key>
@@ -1438,40 +1433,37 @@
 					<string>$self</string>
 				</dict>
 			</array>
-			<key>repository</key>
-			<dict>
-				<key>nest_curly_and_self</key>
+		</dict>
+		<key>nest_curly_and_self</key>
+		<dict>
+			<key>patterns</key>
+			<array>
 				<dict>
+					<key>begin</key>
+					<string>\{</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.scope.elixir</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>begin</key>
-							<string>\{</string>
-							<key>captures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.section.scope.elixir</string>
-								</dict>
-							</dict>
-							<key>end</key>
-							<string>\}</string>
-							<key>patterns</key>
-							<array>
-								<dict>
-									<key>include</key>
-									<string>#nest_curly_and_self</string>
-								</dict>
-							</array>
-						</dict>
-						<dict>
 							<key>include</key>
-							<string>$self</string>
+							<string>#nest_curly_and_self</string>
 						</dict>
 					</array>
 				</dict>
-			</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
Fixes #161 by reverting part of 77a2d7cd189769f25e9554f19dd1a1b756e069de.

For some reason, making `#nest_curly_and_self` a nested repository prevents its end pattern `}` from matching first.

Pulling it back out to the top-level repository lets `#nest_curly_and_self` end any blocks it started, thus letting `#interpolated_elixir` find its end pattern at the correct scope level.

![1](https://user-images.githubusercontent.com/4433966/50828794-5a663c00-137d-11e9-8b2a-5f68ab92606d.png)

Ping @tompave @infininight.
