### PR TITLE
Custom command

### DIFF
--- a/Settings/Elixir.sublime-settings
+++ b/Settings/Elixir.sublime-settings
@@ -1,4 +1,6 @@
 {
+  "mix_format_command": "mix format",
+  "make_path_relative": false,
   "mix_format_on_save": false,
   "reload_after_mix_format": false,
   "use_root_dir": false

--- a/mix_format_file.py
+++ b/mix_format_file.py
@@ -36,8 +36,12 @@ class MixFormatFileWithoutSaveCommand(sublime_plugin.TextCommand):
         path_separator = ';'
 
     file_name = self.view.file_name()
-    cmd = ['mix', 'format', file_name]
     cwd = self.find_cwd(window, settings, file_name)
+
+    if settings.get('make_path_relative', False):
+      file_name = self.make_path_relative(file_name, cwd)
+
+    cmd = settings.get('mix_format_command', 'mix format').split(' ') + [file_name]
 
     p = subprocess.Popen(
       cmd,
@@ -87,7 +91,8 @@ class MixFormatFileWithoutSaveCommand(sublime_plugin.TextCommand):
 
     return cwd
 
-
+  def make_path_relative(self, file_name, cwd):
+    return file_name.replace(cwd, '.')
 
 
 


### PR DESCRIPTION
Regarding this issue: https://github.com/elixir-editors/elixir-tmbundle/issues/175

Two options added:
- `mix_format_command`: allow to trigger a custom command instead of `mix format only`
- `make_path_relative`: which may be necessary if file is contenerized and path varies. I left it as an option as it is very naive and may not work on every environment (tested under linux)

Everything's backward compatible.

Hope it will be useful.

Best