### PR TITLE
Add the function call pattern to syntax

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -43,6 +43,28 @@
 			</array>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.class.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.method.elixir</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.elixir</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>([A-Z]\w+)(\.)([a-z_]\w*[!?]?)</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>\b(fn)\b(?=.*-&gt;)</string>
 			<key>beginCaptures</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -50,19 +50,19 @@
 					<key>name</key>
 					<string>entity.name.type.class.elixir</string>
 				</dict>
-				<key>2</key>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.separator.method.elixir</string>
 				</dict>
-				<key>3</key>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.function.elixir</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([A-Z]\w+)(\.)([a-z_]\w*[!?]?)</string>
+			<string>([A-Z]\w+)(\s*)(\.)(\s*)([a-z_]\w*[!?]?)</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -529,7 +529,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b[a-z_]\w*[!?]?(?=\.?\()</string>
+					<string>\b[a-z_]\w*[!?]?(?=\s*?\.?\s*?\()</string>
 					<key>name</key>
 					<string>entity.name.function.elixir</string>
 				</dict>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -506,6 +506,12 @@
 					<string>variable.language.elixir</string>
 				</dict>
 				<dict>
+					<key>match</key>
+					<string>\b[a-z_]\w*[!?]?(?=\.?\()</string>
+					<key>name</key>
+					<string>entity.name.function.elixir</string>
+				</dict>
+				<dict>
 					<key>captures</key>
 					<dict>
 						<key>1</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -50,19 +50,25 @@
 					<key>name</key>
 					<string>entity.name.type.class.elixir</string>
 				</dict>
-				<key>3</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.separator.method.elixir</string>
 				</dict>
-				<key>5</key>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.function.elixir</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>([A-Z]\w+)(\s*)(\.)(\s*)([a-z_]\w*[!?]?)</string>
+			<string>([A-Z]\w+)\s*(\.)\s*([a-z_]\w*[!?]?)</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b[a-z_]\w*[!?]?(?=\s*\.?\s*\()</string>
+			<key>name</key>
+			<string>entity.name.function.elixir</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -526,12 +532,6 @@
 					<string>\b(__(CALLER|ENV|MODULE|DIR|STACKTRACE)__)\b(?![?!])</string>
 					<key>name</key>
 					<string>variable.language.elixir</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b[a-z_]\w*[!?]?(?=\s*?\.?\s*?\()</string>
-					<key>name</key>
-					<string>entity.name.function.elixir</string>
 				</dict>
 				<dict>
 					<key>captures</key>


### PR DESCRIPTION
## Description

Add the pattern to scope the function calls with parenthesis or dot and
parenthesis. Allowing themes to change the color of function calls.

![Screen Shot 2019-08-16 at 02 32 35](https://user-images.githubusercontent.com/17054180/63145609-6dee1b00-bfce-11e9-9f91-8180d6bca743.png)

## Motivation

Currently the Elixir syntax does not support function calls and it simple does not evaluate a scope for it. This happens mainly because in Elixir you can call a function without the parenthesis, so variables and function can look the same. 

In this context we have some considerations:

### The compile raise a ambiguity warning

In Elixir community we that the quote "Explicit is better than implicit" so the compiler will warn the developer about a call that looks like a variable but actually is a function call.
![The warning raised by the compiler](https://user-images.githubusercontent.com/17054180/63146345-05546d80-bfd1-11e9-8768-581bd8afdd75.png)

### The code formatter

By default it will add the parenthesis to ambiguous calls.
![Formatter adding the parenthesis to a function call](https://user-images.githubusercontent.com/17054180/63146823-a8f24d80-bfd2-11e9-9650-2543d0609443.gif)

### Ambiguous calls will stay exactly the same

Thats it, if you enjoy the ambiguous calls they will stay the same.