### PR TITLE
Add function call syntax without parenthesis

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -87,6 +87,23 @@
 			<string>(\:\w+)\s*(\.)\s*([_]?\w*[!?]?)</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.other.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.elixir</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(\|\>)\s*([a-z_]\w*[!?]?)</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\b[a-z_]\w*[!?]?(?=\s*\.?\s*\()</string>
 			<key>name</key>

--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -65,6 +65,28 @@
 			<string>([A-Z]\w+)\s*(\.)\s*([a-z_]\w*[!?]?)</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.other.symbol.elixir</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.method.elixir</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.elixir</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(\:\w+)\s*(\.)\s*([_]?\w*[!?]?)</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\b[a-z_]\w*[!?]?(?=\s*\.?\s*\()</string>
 			<key>name</key>


### PR DESCRIPTION
I came across two unattended cases after we merged #179, both related to calls without parenthesis.

One is calls to erlang module functions without parenthesis and other one is calls of functions without parenthesis on pipes.

<details>
<summary>Before</summary>
<img width="407" alt="Screen Shot 2019-09-07 at 19 40 43" src="https://user-images.githubusercontent.com/17054180/64480909-e8622300-d1a7-11e9-9cc7-ff8e68778b1e.png">
</details>

<details>
<summary>After</summary>
<img width="413" alt="Screen Shot 2019-09-07 at 19 41 30" src="https://user-images.githubusercontent.com/17054180/64480911-eac47d00-d1a7-11e9-869c-9809c83c9086.png">
</details>

I made one commit for each case but if needed I can open different PRs for each one. :smile: