### PR TITLE
enable syntax highlinging for inline leex templates using ~L""" sigil

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -451,6 +451,27 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>\s*~L"""</string>
+					<key>comment</key>
+					<string>Leex Sigil</string>
+					<key>end</key>
+					<string>\s*"""</string>
+					<key>name</key>
+					<string>sigil.leex</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>text.elixir</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>text.html.basic</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>@(module|type)?doc (~[a-z])?"""</string>
 					<key>comment</key>
 					<string>@doc with heredocs is treated as documentation</string>


### PR DESCRIPTION
I have never done anything with tmLanguage, so this is probably a very naive first attempt. It does work though, and I am using it now :)

This is how it looks right now. It would be nice if the `~L"""` and `"""` parts were highlighted in yellow like normal. I'm not sure how to do that. 

![Screenshot from 2020-06-24 10-17-55](https://user-images.githubusercontent.com/4594800/85583593-03513700-b604-11ea-8662-682156666b85.png)

#184 