### PR TITLE
Don't match double under as comment

### DIFF
--- a/Syntaxes/Elixir.tmLanguage
+++ b/Syntaxes/Elixir.tmLanguage
@@ -1351,7 +1351,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b_([\w]+[?!]?)</string>
+					<string>\b_([^_][\w]+[?!]?)</string>
 					<key>name</key>
 					<string>comment.unused.elixir</string>
 				</dict>


### PR DESCRIPTION
This PR tweaks the regex that tries to match ignored arguments to treat them as comments (Added in https://github.com/elixir-editors/elixir-tmbundle/pull/182).

It now checks for words that start with a _single_ underscore so that fields don't get matched.

For example `__private__`:

<img width="517" alt="Screen Shot 2020-12-25 at 6 11 36 PM" src="https://user-images.githubusercontent.com/39946/103144457-6ff5dd00-46de-11eb-800b-099013f92681.png">

Now renders as: 

<img width="574" alt="Screen Shot 2020-12-25 at 6 24 44 PM" src="https://user-images.githubusercontent.com/39946/103144460-7b490880-46de-11eb-8678-1e95e84da34a.png">
